### PR TITLE
Add language validation to WPML_Post_Helper::set_language method

### DIFF
--- a/docs/Helpers/wpml-post-helper.md
+++ b/docs/Helpers/wpml-post-helper.md
@@ -103,6 +103,38 @@ wp_set_post_terms($post_id, $new_tags, 'post_tag');
 
 **Important**: This method temporarily switches WPML language context to ensure term relationships are deleted in all language contexts, then restores the original language.
 
+### set_language()
+
+Set or update a post's language assignment in WPML. This method can be used to fix posts with no language assignment, change a post's language, or reassign posts from deactivated languages.
+
+```php
+// Assign language to a post
+$result = WPML_Post_Helper::set_language(123, 'de');
+if (is_wp_error($result)) {
+    echo 'Error: ' . $result->get_error_message();
+} elseif ($result) {
+    echo 'Language successfully set!';
+}
+
+// Change a post's language
+$post = get_post(456);
+$result = WPML_Post_Helper::set_language($post, 'fr');
+
+// Handle validation errors
+$result = WPML_Post_Helper::set_language(789, 'invalid_lang');
+if (is_wp_error($result) && $result->get_error_code() === 'invalid_language') {
+    // Language code is not configured in WPML
+    echo $result->get_error_message(); // "Language "invalid_lang" is not configured in WPML."
+}
+```
+
+**Returns**: 
+- `true` if the language was set successfully
+- `false` if the post ID is invalid or post type cannot be determined
+- `WP_Error` if the target language is not configured in WPML
+
+**Note**: This method validates that the target language is active in WPML before attempting to set it.
+
 ## Practical Examples
 
 ### Example 1: Display Translation Status in Admin

--- a/src/Helpers/WPML_Post_Helper.php
+++ b/src/Helpers/WPML_Post_Helper.php
@@ -242,13 +242,26 @@ class WPML_Post_Helper {
 	 *
 	 * @param int|WP_Post $post            Post ID or WP_Post object.
 	 * @param string      $target_language The target language code to assign.
-	 * @return bool True if language was set successfully, false otherwise.
+	 * @return bool|\WP_Error True if language was set successfully, false for invalid post, 
+	 *                        WP_Error if target language is not configured in WPML.
 	 */
-	public static function set_language( int|WP_Post $post, string $target_language ): bool {
+	public static function set_language( int|WP_Post $post, string $target_language ): bool|\WP_Error {
 		$post_id = is_object( $post ) ? $post->ID : (int) $post;
 
 		if ( ! $post_id ) {
 			return false;
+		}
+
+		// Validate that the target language is configured in WPML
+		if ( ! WPML_Language_Helper::is_language_active( $target_language ) ) {
+			return new \WP_Error(
+				'invalid_language',
+				sprintf(
+					/* translators: %s: Language code */
+					__( 'Language "%s" is not configured in WPML.', 'multilingual-bridge' ),
+					$target_language
+				)
+			);
 		}
 
 		// Get post type for the element type

--- a/src/Helpers/WPML_Post_Helper.php
+++ b/src/Helpers/WPML_Post_Helper.php
@@ -242,7 +242,7 @@ class WPML_Post_Helper {
 	 *
 	 * @param int|WP_Post $post            Post ID or WP_Post object.
 	 * @param string      $target_language The target language code to assign.
-	 * @return bool|\WP_Error True if language was set successfully, false for invalid post, 
+	 * @return bool|\WP_Error True if language was set successfully, false for invalid post,
 	 *                        WP_Error if target language is not configured in WPML.
 	 */
 	public static function set_language( int|WP_Post $post, string $target_language ): bool|\WP_Error {


### PR DESCRIPTION
## Summary
- Added validation to check if the target language is configured in WPML before attempting to set it
- Returns a `WP_Error` with a descriptive message when an invalid language code is provided
- Updated method signature to return `bool|WP_Error` instead of just `bool`

## Changes
- Modified `set_language()` method in `WPML_Post_Helper` class to validate language codes
- Added language validation using `WPML_Language_Helper::is_language_active()`
- Returns `WP_Error` with code `invalid_language` for unconfigured languages
- Updated PHPDoc to reflect the new return type
- Added comprehensive documentation for the `set_language()` method in the docs

## Backward Compatibility
- Maintains backward compatibility by returning `false` for invalid posts (existing behavior)
- Only returns `WP_Error` for the new validation case (invalid language)